### PR TITLE
Fix/get signed url no promise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.1.5"></a>
+## [1.1.5](https://github.com/rcdef/jest-mockies/compare/v1.1.4...v1.1.5) (2019-07-06)
+
+
+
 <a name="1.1.4"></a>
 ## [1.1.4](https://github.com/rcdef/jest-mockies/compare/v1.1.3...v1.1.4) (2019-07-06)
 

--- a/dist/aws-sdk/s3.js
+++ b/dist/aws-sdk/s3.js
@@ -39,11 +39,7 @@ var _default = {
     }, {
       key: "getSignedUrl",
       value: function getSignedUrl(params) {
-        return {
-          promise: function promise() {
-            return mockGetSignedUrl(params);
-          }
-        };
+        return mockGetSignedUrl(params);
       }
     }]);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-mockies",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "main": "./dist/index.js",
   "license": "MIT",
   "devDependencies": {

--- a/src/aws-sdk/s3.js
+++ b/src/aws-sdk/s3.js
@@ -17,9 +17,7 @@ export default {
     }
 
     getSignedUrl(params) {
-      return {
-        promise: () => mockGetSignedUrl(params)
-      };
+      return mockGetSignedUrl(params);
     }
   }
 };


### PR DESCRIPTION
S3.getSignedUrl has no `promise`, therefore this PR is to removing it.